### PR TITLE
implemented comment gobbling in scan.l

### DIFF
--- a/lexical_analyzer/scan.l
+++ b/lexical_analyzer/scan.l
@@ -21,7 +21,7 @@ id ({letter}|_)({letter}|{digit}|_)*
 integer [+|-]?{digit}+
 bad_id ({digit})({digit}|{letter}|_)*
 
-%x string
+%x string MULTICOMMENT SINGLECOMMENT
 
 %%
 
@@ -40,6 +40,18 @@ bad_id ({digit})({digit}|{letter}|_)*
   return STRING_T;
 }
 <string>.     { yymore(); }
+
+"/*"            { BEGIN(MULTICOMMENT); }
+<MULTICOMMENT>[^*\n]+ /* Gobble comment */
+<MULTICOMMENT>"*" /* Gobble star */
+<MULTICOMMENT>\n /* Gobble new line */
+<MULTICOMMENT>"*/" {
+  BEGIN(INITIAL);
+}
+
+"//"          { BEGIN(SINGLECOMMENT); }
+<SINGLECOMMENT>[^\n] /* Gobble comment */
+<SINGLECOMMENT>\n { BEGIN(INITIAL); }
 
 "+"           return ADD_T;
 "-"           return SUB_T;


### PR DESCRIPTION
Added comment gobbling for both single line and multi-line C-style comments. The comment token is currently not returned and instead anything within matched comment patterns is simply ignored. The MULTICOMMENT start condition is used for scanning multi-line comments while the SINGLECOMMENT start condition is used for scanning single line comments. These start conditions are defined in the declaration section